### PR TITLE
Replace hash (#) character by underscore (_).

### DIFF
--- a/on-modify.hamster
+++ b/on-modify.hamster
@@ -35,7 +35,8 @@ if not hamster_cli:
 
 # "start" command used
 if ('start' not in old_task and 'start' in mod_task):
-    cmd_arg = '{}'.format(desc)
+    # replace # symbol in description
+    cmd_arg = '{}'.format(desc.replace('#', '_'))
     if proj:
         cmd_arg += '@{}'.format(proj)
     if tags:


### PR DESCRIPTION
I am using bugwarrior to pull issues from redmine, and bugwarrior uses the #-character in task descriptions, like e.g:

`(bw)Is#5543 - Personen die stoppen en terug begin .. https://websites.chiro.be/issues/5543`

If this is synced as-is to hamster, an activity '(bw)Is' is started, and that is not what I want.

By replacing # by  _, I work around the problem. It's hacky, but it works.